### PR TITLE
(PE-11434) Enable travisci as per tk-webserver-jetty9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: clojure
 lein: lein2
 jdk:
-- oraclejdk7
-- openjdk7
+  - oraclejdk7
+  - openjdk7
+script: ./ext/travisci/test.sh
+notifications:
+  email: false

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+lein2 test


### PR DESCRIPTION
Configuration copied from trapperkeeper-webserver-jetty9 master branch
at ee86ab0bd8271ae678403efb31b8a935be10462d
